### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 .. image:: https://travis-ci.org/winny-/sc2bank.png?branch=master
    :target: https://travis-ci.org/winny-/sc2bank
    :alt: Build Status
-.. image:: https://pypip.in/v/sc2bank/badge.png
+.. image:: https://img.shields.io/pypi/v/sc2bank.svg
    :target: https://pypi.python.org/pypi/sc2bank
    :alt: Latest PyPi Package
 .. image:: https://coveralls.io/repos/winny-/sc2bank/badge.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20sc2bank))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `sc2bank`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.